### PR TITLE
Attempt to Fix Loading Error on GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,6 @@
       </tbody>
     </table>
   </div>
-    <script src="http://load.sheetsu.com"></script>
+    <script src="//load.sheetsu.com"></script>
   </body>
 </html>


### PR DESCRIPTION
The http is used in a non-http server editor, but is no longer used when deploying on GitHub pages.